### PR TITLE
Fix error: ‘SA_RESTART’ undeclared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME    := xdo
 VERCMD  ?= git describe 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
 
-CPPFLAGS += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"
+CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra
 LDLIBS   := -lxcb -lxcb-util -lxcb-icccm -lxcb-ewmh -lxcb-xtest
 


### PR DESCRIPTION
# Fix "error: ‘SA_RESTART’ undeclared"

Distribution: Ubuntu 16.04.3 LTS

## Steps to reproduce
```
$ git clone -q https://github.com/baskerville/xdo .
$ make
cc -std=c99 -pedantic -Wall -Wextra -D_POSIX_C_SOURCE=200112L -DVERSION=\"0.5.6-2-g5477ada\"  -c -o xdo.o xdo.c
xdo.c: In function ‘main’:
xdo.c:134:16: error: ‘SA_RESTART’ undeclared (first use in this function)
  sa.sa_flags = SA_RESTART;
                ^
xdo.c:134:16: note: each undeclared identifier is reported only once for each function it appears in
<builtin>: recipe for target 'xdo.o' failed
make: *** [xdo.o] Error 1
```

## References

* [Stackoverflow](https://stackoverflow.com/a/9829389)